### PR TITLE
bumping wordpress compatibility to 5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
-FROM radius314/wordpress:5.0.0-nightly-php7.3-rc-apache
+FROM wordpress:5.4.0-php7.2-apache
 
 RUN apt-get update && \
 	apt-get install -y  --no-install-recommends ssl-cert && \
 	rm -r /var/lib/apt/lists/* && \
-	a2enmod ssl && \
+	a2enmod ssl rewrite expires && \
 	a2ensite default-ssl
+
+ENV PHP_INI_PATH "/usr/local/etc/php/php.ini"
+
+RUN pecl install xdebug-2.6.1 && docker-php-ext-enable xdebug \
+    && echo "xdebug.remote_port=9000" >> ${PHP_INI_PATH} \
+    && echo "xdebug.remote_enable=1" >> ${PHP_INI_PATH} \
+    && echo "xdebug.remote_connect_back=0" >> ${PHP_INI_PATH} \
+    && echo "xdebug.remote_host=docker.for.mac.localhost" >> ${PHP_INI_PATH} \
+    && echo "xdebug.idekey=IDEA_DEBUG" >> ${PHP_INI_PATH} \
+    && echo "xdebug.remote_autostart=1" >> ${PHP_INI_PATH} \
+    && echo "xdebug.remote_log=/tmp/xdebug.log" >> ${PHP_INI_PATH}
 
 EXPOSE 80
 EXPOSE 443

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: paulnagle, bmltenabled, pjaudiomv
 Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, bmlt
 Requires at least: 4.0
 Required PHP: 5.6
-Tested up to: 5.2.2
+Tested up to: 5.4.0
 Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I bumped all bmlt readmes in svn to 5.4 https://wordpress.org/plugins/search/bmlt/ this just updates repo