### PR TITLE
change tomato url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6.0.2-php8.0-apache
+FROM wordpress:6.1.1-php8.0-apache
 
 RUN apt-get update && \
 	apt-get install -y  --no-install-recommends ssl-cert && \

--- a/bmlt_tabbed_map.php
+++ b/bmlt_tabbed_map.php
@@ -6,7 +6,7 @@
  * Plugin Name:       BMLT Tabbed Map
  * Plugin URI:        https://bmlt.app
  * Description:       A plugin to display NA Meetings from the BMLT Tomato server on a map, tabbed by weekday.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Author:            Paul N
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt

--- a/public/js/bmlt_tabbed_map-public.js
+++ b/public/js/bmlt_tabbed_map-public.js
@@ -186,7 +186,7 @@ const bmltTabbedMapJS = function ($) {
   }
 
   var buildSearchURL = function () {
-    var search_url = "https://tomato.na-bmlt.org/main_server/client_interface/json/";
+    var search_url = "https://tomato.bmltenabled.org/main_server/client_interface/json/";
     search_url += "?switcher=GetSearchResults";
     search_url += "&geo_width_km=" + getMapCornerDistance();
     search_url += "&long_val=" + map.getCenter().lng;

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Contributors: paulnagle, bmltenabled, pjaudiomv
 Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, bmlt
 Requires at least: 4.0
 Required PHP: 5.6
-Tested up to: 5.9.3
-Stable tag: 1.1.0
+Tested up to: 6.1.1
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 bmlt_tabbed_map implements a Tabbed Map for BMLT.
@@ -30,6 +30,10 @@ This plugin provides a Tabbed Map interface for the Basic Meeting List Toolbox (
 <a href="https://www.na-ireland.org/na-meetings/meeting-search"> Go to this Web page to get an idea of how this works.</a>
 
 == Changelog ==
+
+= 1.1.1 =
+
+Changed tomato url
 
 = 1.1.0 =
 


### PR DESCRIPTION
theres no plan to deprecate old url, but you gotta start somwhere if we ever want to.